### PR TITLE
Adding changelog and ensuring that tags are sorted for 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# CHANGELOG
+
+This file briefly lists changes associated with tagged (released) versions.
+Critical items to know are:
+
+ - renamed commands
+ - deprecated / removed commands
+ - changed defaults
+ - backward incompatible changes (recipe or image file format?)
+ - migration guidance (how to convert images?)
+ - changed behaviour (recipe sections work differently)
+
+## [master](https://github.com/rseng/good-first-issues/tree/master)
+ - ensure tags are sorted (v1.0.1)
+ - first tagged released associated with blog post (v1.0.0)
+

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/singularityhub/sregistry containers,singularity
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Generate First Issues
-      uses: rseng/good-first-issues@v1.0.0
+      uses: rseng/good-first-issues@v1.0.1
       with:
         repos-file: '.github/repos.txt'
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/generate-first-issues.py
+++ b/scripts/generate-first-issues.py
@@ -67,6 +67,7 @@ for line in lines:
             tags = tags + extra_tags
         if tags:
             tags = [x.replace(":", "").replace(" ", "-") for x in tags]
+            tags.sort()
             content += "tags: %s\n" % (",".join(tags))
         for param in ["title", "html_url"]:
             content += '%s: "%s"\n' % (param, issue[param])


### PR DESCRIPTION
Currently, a PR will be issued with "changes" when the changes only constitute a different ordering of tags. We should ensure that tag ordering is consistent for version 1.0.1. I'm also adding a CHANGELOG to keep track of these changes.

Signed-off-by: vsoch <vsochat@stanford.edu>