### PR TITLE
Fixing issue with escaping quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ than one collection, you can change this to something else.
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Generate First Issues
-      uses: rseng/good-first-issues@v1.0.2
+      uses: rseng/good-first-issues@v1.0.3
       with:
         repos-file: '.github/repos.txt'
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,7 +61,7 @@ Here is how you might update the label used:
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Generate First Issues
-      uses: rseng/good-first-issues@v1.0.2
+      uses: rseng/good-first-issues@v1.0.3
       with:
         label: 'bug'
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ as a relative path to the docs folder, I can set that as follows:
     - name: Checkout Code
       uses: actions/checkout@v2
     - name: Generate First Issues
-      uses: rseng/good-first-issues@v1.0.2
+      uses: rseng/good-first-issues@v1.0.3
       with:
         collection: '_another'
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/generate-first-issues.py
+++ b/scripts/generate-first-issues.py
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+import json
 import os
 import requests
 import sys
@@ -48,7 +49,7 @@ for line in lines:
     try:
         repo, extra_tags = line.strip().split(" ")
     except ValueError:
-        repo = line.strip()    
+        repo = line.strip()
 
     extra_tags = extra_tags.split(",")
     repo = "/".join(repo.split("/")[-2:])
@@ -81,9 +82,12 @@ for line in lines:
         if tags:
             tags = [x.replace(":", "").replace(" ", "-") for x in tags]
             tags.sort()
+            print("Adding tags %s" % ",".join(tags))
             content += "tags: %s\n" % (",".join(tags))
-        for param in ["title", "html_url"]:
-            content += '%s: "%s"\n' % (param, issue[param])
+
+        # Title must have quotes escaped
+        content += 'title: %s\n' % json.dumps(issue["title"])
+        content += 'html_url: "%s"\n' % issue["html_url"]
         content += "user: %s\n" % (issue["user"]["login"])
         content += "repo: %s\n" % repo
         content += "---\n\n"


### PR DESCRIPTION
This addresses two issues:

 - a repo added without tags will currently trigger an error
 - quotes in titles are not escaped.

This has been tested at https://github.com/rseng/needs-love and is an improvement, the bugs are fixed.